### PR TITLE
Fix Wargaming API requests blocked by CORS

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,48 @@ router.get('/env', function(req, res) {
 	res.json(env);
 });
 
+// Proxy batch requests through the local server because the Wargaming API
+// does not allow cross-origin browser requests from localhost.
+function proxyWowsApi(res, path) {
+	request(process.env.WOWS_API_URL + path, function(error, response, body) {
+		if (error) {
+			return res.status(502).json({
+				status: 'error',
+				error: { message: error.message }
+			});
+		}
+
+		res.status(response.statusCode);
+		res.type('application/json');
+		return res.send(body);
+	});
+}
+
+router.get('/shipinfo', function(req, res) {
+	if (!req.query.ship_id || !/^\d+(,\d+)*$/.test(req.query.ship_id))
+		return res.sendStatus(400);
+
+	proxyWowsApi(res, '/wows/encyclopedia/ships/?application_id=' + api_key +
+		'&fields=name%2Ctier%2Ctype%2Cnation&language=en&ship_id=' +
+		encodeURIComponent(req.query.ship_id));
+});
+
+router.get('/accountlist', function(req, res) {
+	if (!req.query.search || req.query.search.length > 2000)
+		return res.sendStatus(400);
+
+	proxyWowsApi(res, '/wows/account/list/?application_id=' + api_key +
+		'&search=' + encodeURIComponent(req.query.search) + '&type=exact');
+});
+
+router.get('/claninfo', function(req, res) {
+	if (!req.query.account_id || !/^\d+(,\d+)*$/.test(req.query.account_id))
+		return res.sendStatus(400);
+
+	proxyWowsApi(res, '/wows/clans/accountinfo/?application_id=' + api_key +
+		'&account_id=' + encodeURIComponent(req.query.account_id) + '&extra=clan');
+});
+
 router.post('/path', jsonParser, function(req, res) {
 	if (req.body.path) {
 		fs.access(req.body.path + "/WorldOfWarships.exe", fs.R_OK, function (err) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -182,7 +182,7 @@ function get_shipinfo(idArray) {
 	sync_getenv.then ( function () {
 		var sync_getinfo = new Promise (function (resolve, reject) {
 				var idString = idArray.join('%2C');
-				var api_call = api_url + '/wows/encyclopedia/ships/?application_id=' + api_key + '&fields=name%2Ctier%2Ctype%2Cnation&language=en&ship_id=' + idString;
+				var api_call = '/api/shipinfo?ship_id=' + idString;
 				ship_info = {};
 
 				jQuery.ajax({
@@ -238,7 +238,7 @@ function getClanList(nArray) {
 
 	var sync_getAccountId = new Promise (function (resolve, reject) {
 		var nameSrings = nameList.join(',');
-		var api_call = api_url + '/wows/account/list/?application_id=' + api_key + '&search=' + encodeURIComponent(nameSrings) + '&type=exact';
+		var api_call = '/api/accountlist?search=' + encodeURIComponent(nameSrings);
 //		console.log(api_call);
 		jQuery.ajax({
 			type: 'GET',
@@ -296,7 +296,7 @@ function getClanList(nArray) {
 
 		var sync_getClanInfo = new Promise (function (resolve, reject) {
 			var accountIdSrings = idList.join('%2c');
-			var api_call = api_url + '/wows/clans/accountinfo/?application_id=' + api_key + '&account_id=' + accountIdSrings + '&extra=clan';
+			var api_call = '/api/claninfo?account_id=' + accountIdSrings;
 //			console.log(api_call);
 			jQuery.ajax({
 				type: 'GET',


### PR DESCRIPTION
# Fix Wargaming API requests blocked by CORS

## Summary

Proxy the browser-side batch requests for ship, account, and clan data through the local Express server.

The Wargaming API no longer includes an `Access-Control-Allow-Origin` response header for these requests. As a result, browsers block calls made directly from `http://localhost:8080`, and the statistics view never finishes loading.

## Reproduction

1. Start wows-stats-plus and enter a battle.
2. Open the statistics page in Chrome.
3. Observe that the battle participants and statistics are not displayed.
4. Open the browser console and observe an error similar to:

   ```text
   Access to XMLHttpRequest at 'http://api.worldofwarships.asia/...'
   from origin 'http://localhost:8080' has been blocked by CORS policy:
   No 'Access-Control-Allow-Origin' header is present on the requested resource.
   ```

The local `/api/arena`, `/api/player`, and `/api/ship` endpoints continue to work; only the browser's direct cross-origin batch requests fail.

## Changes

- Add local proxy endpoints for:
  - batch ship information
  - exact account lookup
  - batch clan information
- Change the browser client to call those same-origin endpoints.
- Validate numeric ship/account ID lists before forwarding them.
- Return HTTP 502 with a JSON error when an upstream request fails.
- Keep the upstream paths fixed instead of exposing a general-purpose proxy.

## Verification

- `node --check index.js`
- `node --check static/js/app.js`
- `git diff --check`
- Confirmed the original failure with a live battle: `/api/arena` returned all 24 vehicles and the browser reported the CORS error for `/wows/encyclopedia/ships/`.
- Confirmed the existing local ship endpoint could retrieve ship and player ship-stat data, showing that the configured Wargaming API URL and application ID were valid.

## Notes

This change leaves the existing per-player and per-ship local API behavior unchanged. It only moves the three browser-side cross-origin requests behind the existing local server.
